### PR TITLE
Arp0808

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
 # arp-yang-draft
 IETF draft for ARP YANG model
+
+Comments of Tom Petch
+1.08/02/2018
+Another YANG I-D from the Routing Area; I wonder what I will find if I browse it:-)
+
+- Abstract contains a [Reference]
+
+- No reference for YANG Tree Diagrams
+
+- No mention of the current YANG 1.1 RFC
+
+- No YANG version statement in the module
+
+- No mention of NMDA in the body of the I-D (but it does appear in the YANG Module)
+
+- No references for the imported modules and the RFC in question do not appear in the I-D Normative References
+
+- YANG module references RFC8242 which does not appear in the I-D Normative References
+
+- RFC 6536 is obsolete
+
+2.07/31/2018
+This I-D
+
+- fails to mention whether or not it is NMDA compliant in the Abstract and Introduction
+
+- fails to use the current definitions of terminology from RFC8342
+
+- references the old version of RFC2119 key words
+
+- has no Note to the RFC Editor asking them to replace the YANG module dates with date of publication.  I suggest a Note asking them to replace XXXX with the number assigned to this I-D at the start of the I-D rather than asking them to replace 'draft-ding-rtgwg-arp-yang-model-02 ' which, should this I-D be adopted, will be wrong
+
+- has no Copyright statement in the YANG module
+
+- lacks references for several imported modules.
+
+- starts Section 4 well with a good sentence but fails to mention most imports
+
+- has serious formatting problems with the text in the YANG module with lines being way too long for an RFC (it is probably not a coincidence that other I-Ds have had the same problem -  the right options in pyang fix this AFAIK)
+
+- has no IANA Considerations; no IANA Considerations means that you are not producing a YANG module no matter what it looks like.
+
+- Security Considerations are much better than usual but lack detail of sensitive nodes
+
+- Tree diagrams has the right reference but then spoils it by including text about the symbols
+
+- has out of date references
+   [I-D.ietf-netmod-rfc7223bis]
+   [I-D.ietf-netmod-rfc7277bis]
+which belie the claimed date of  June 28, 2018 for this I-D; 2018-01-27 looks more like it:-)
+
+- has arp as a Informative Reference - Normative I think.
+
+
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ IETF draft for ARP YANG model
 
 Comments of Tom Petch
 1.08/02/2018
-Another YANG I-D from the Routing Area; I wonder what I will find if I browse it:-)
+Another YANG I-D from the Routing Area; 
 
 - Abstract contains a [Reference]
 

--- a/draft-ding-rtgwg-arp-yang-model-03.xml
+++ b/draft-ding-rtgwg-arp-yang-model-03.xml
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!-- This template is for creating an Internet Draft using xml2rfc,               
     which is available here: http://xml.resource.org. -->
+
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
 <!-- One method to get references from the online citation libraries.             
     There has to be one entity for each item to be referenced.                    
     An alternate method (rfc include) is described in the references. -->
-<!ENTITY rfc826 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.0826.xml">
+<!ENTITY rfc0826 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.0826.xml">
 <!ENTITY rfc1027 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.1027.xml">
 <!ENTITY rfc2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
-<!ENTITY rfc2697 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2697.xml">
-<!ENTITY rfc2698 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2698.xml">
+<!ENTITY rfc3688 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3688.xml">
 <!ENTITY rfc6241 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6241.xml">
-<!ENTITY rfc6536 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6536.xml">
 <!ENTITY rfc6991 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6991.xml">
 <!ENTITY rfc7950 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7950.xml">
 <!ENTITY rfc8040 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8040.xml">
 <!ENTITY rfc8174 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8174.xml">
 <!ENTITY rfc8340 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8340.xml">
+<!ENTITY rfc8341 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8341.xml">
 <!ENTITY rfc8342 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8342.xml">
 <!ENTITY rfc8343 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8343.xml">
 <!ENTITY rfc8344 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8344.xml">
 ]>
+
 <rfc category="std" docName="draft-ding-rtgwg-arp-yang-model-03"
      ipr="trust200902">
   <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
@@ -52,26 +53,6 @@
   <front>
     <title abbrev="ARP YANG model">YANG Data Model for ARP</title>
 
-    <author fullname="Xiaojian Ding" initials="X." surname="Ding">
-      <organization>Huawei</organization>
-
-      <address>
-        <postal>
-          <street>101 Software Avenue, Yuhua District</street>
-
-          <city>Nanjing</city>
-
-          <region>Jiangsu</region>
-
-          <code>210012</code>
-
-          <country>China</country>
-        </postal>
-
-        <email>dingxiaojian1@huawei.com</email>
-      </address>
-    </author>
-
     <author fullname="Feng Zheng" initials="F." surname="Zheng">
       <organization>Huawei</organization>
 
@@ -92,6 +73,14 @@
       </address>
     </author>
 
+    <author fullname="Bo Wu" initials="B" surname="Wu">
+      <organization>Huawei</organization>
+
+      <address>
+        <email>lana.wubo@huawei.com</email>
+      </address>
+    </author>
+
     <author fullname="Robert Wilton" initials="R" surname="Wilton">
       <organization>Cisco Systems</organization>
 
@@ -100,68 +89,128 @@
       </address>
     </author>
 
+    <author fullname="Xiaojian Ding" initials="X." surname="Ding">
+      <address>
+        <email>wjswsl@163.com</email>
+      </address>
+    </author>
+
     <date year="2018"/>
-	
+
     <area>Routing Area</area>
 
     <workgroup>RTGWG</workgroup>
 
     <abstract>
-      <t>This document defines a YANG data model for the management of the Address Resolution Protocol (ARP).
-      It extends the basic ARP functionality contained in the ietf-ip YANG data model, defined in <xref target="RFC8344"/>, to provide management of optional ARP features and statistics.</t>
-      <t>The YANG data model in this document conforms to the Network Management Datastore Architecture defined in <xref target="RFC8342"/>.</t>
+      <t>This document defines a YANG data model for the management of the
+      Address Resolution Protocol (ARP). It extends the basic ARP
+      functionality contained in the ietf-ip YANG data model, defined in <xref
+      target="RFC8344"/>, to provide management of optional ARP features and
+      statistics.</t>
+
+      <t>The YANG data model in this document conforms to the Network
+      Management Datastore Architecture defined in <xref
+      target="RFC8342"/>.</t>
     </abstract>
   </front>
 
   <middle>
-    <section anchor="intro" title="Introduction">  
-	  <t>This document defines a YANG <xref target="RFC7950"/> data model for the Address Resolution
-	  Protocol <xref target="RFC0826"/> implementation and identification of some common properties
-	  within a device. Devices have common properties that need to be configured
-	  and monitored in a standard way. This document is intended to present universal
-	  ARP protocol configuration and many vendors can implement it.
-	  </t>
+    <section anchor="intro" title="Introduction">
+      <t>This document defines a YANG <xref target="RFC7950"/> data model for
+      the Address Resolution Protocol <xref target="RFC0826"/> implementation
+      and identification of some common properties within a device. Devices
+      have common properties that need to be configured and monitored in a
+      standard way. This document is intended to present universal ARP
+      protocol configuration and many vendors can implement it.</t>
 
-      <t>The data model convers configuration of system parameters of ARP, such as
-	  static ARP entries, timeout for dynamic ARP entries, interface ARP, proxy ARP,
-	  and so on. It also provides information about running state of ARP implementations.</t>
+      <t>The data model convers configuration of system parameters of ARP,
+      such as static ARP entries, timeout for dynamic ARP entries, interface
+      ARP, proxy ARP, and so on. It also provides information about running
+      state of ARP implementations.</t>
+
+      <t>The YANG modules in this document conform to the Network Management
+      Datastore Architecture (NMDA) [RFC8342].</t>
+
+      <t></t>
+
+      <t>Editorial Note: (To be removed by RFC Editor)</t>
+
+      <t>This draft contains many placeholder values that need to be replaced
+      with finalized values at the time of publication. Please apply the
+      following replacements</t>
+
+      <t><list style="symbols">
+          <t>"XXXX" --&gt; the assigned RFC value for this draft both in this
+          draft and in the YANG models under the revision statement.</t>
+
+          <t>Revision date in model, in the format 2018-08-01 needs to get
+          updated with the date the draft gets approved. The date also needs
+          to get reflected on the line with &lt;CODE BEGINS&gt;.</t>
+        </list></t>
+
+      <t/>
+
+      <t/>
 
       <section title="Terminology">
-      <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
-   "OPTIONAL" in this document are to be interpreted as described in [BCP 14] <xref target="RFC2119"/> <xref target="RFC8174"/> when, and only when, they appear in all capitals, as shown here.</t>
+        <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+        "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+        "OPTIONAL" in this document are to be interpreted as described in [BCP
+        14] <xref target="RFC2119"/> <xref target="RFC8174"/> when, and only
+        when, they appear in all capitals, as shown here.</t>
 
-        <t>The following terms are defined in <xref target="RFC6241"/> and are not redefined
-        here:</t>
+        <t>The following terms are defined in <xref target="RFC8342"/> and are
+        not redefined here:</t>
 
         <t><list style="symbols">
             <t>client</t>
 
-            <t>configuration data</t>
-
             <t>server</t>
 
+            <t>configuration data</t>
+
+            <t>system state</t>
+
             <t>state data</t>
+
+            <t>intended configuration</t>
+
+            <t>running configuration datastore</t>
+
+            <t>operational state datastore</t>
           </list></t>
+
+        <t>The following terms are defined in <xref target="RFC7950"/> and are
+        not redefined here:</t>
+
+        <t><list style="symbols">
+            <t>augment</t>
+
+            <t>data model</t>
+
+            <t>data node</t>
+          </list></t>
+
+        <t>The terminology for describing YANG data models is found in <xref
+        target="RFC7950"/>.</t>
       </section>
 
       <section title="Tree Diagrams">
-       <t>Tree diagrams used in this document follow the notation defined in <xref target="RFC8340"/></t>		  
-
+        <t>Tree diagrams used in this document follow the notation defined in
+        <xref target="RFC8340"/></t>
       </section>
     </section>
 
     <!-- intro -->
 
     <section anchor="problem" title="Problem Statement">
-      <t>This document defines a YANG <xref target="RFC7950"/> configuration data model that
-	  may be used to configure the ARP feature running on a system. Data model
-	  "ietf-ip" <xref target="RFC8344"/> covers the address mapping
-	  functionality. However, this functionality is strictly dependent on IPv4
-	  networks, and many ARP related functionalities are missing, e.g. device
-	  global ARP entries and control, configuration related to dynamic ARP
-	  learning, proxy ARP, gratuitous ARP, etc. 	
-	  </t>
+      <t>This document defines a YANG <xref target="RFC7950"/> configuration
+      data model that may be used to configure the ARP feature running on a
+      system. Data model "ietf-ip" <xref target="RFC8344"/> covers the address
+      mapping functionality. However, this functionality is strictly dependent
+      on IPv4 networks, and many ARP related functionalities are missing, e.g.
+      device global ARP entries and control, configuration related to dynamic
+      ARP learning, proxy ARP, gratuitous ARP, etc.</t>
 
       <t>The data model makes use of the YANG "feature" construct which allows
       implementations to support only those ARP features that lie within their
@@ -180,55 +229,51 @@
       finds the hardware address, also known as Media Access Control (MAC)
       address, of a host from its known IP address. These tasks include, but
       are not limited to, adding a static entry in the ARP cache, configuring
-      dynamic ARP learning, proxy ARP, gratuitous ARP. There are two kind of 
-	  ARP configurations: global ARP configuration, which is across all
-	  interfaces on the device, and per interface ARP configuration. 
-	  </t>
+      dynamic ARP learning, proxy ARP, gratuitous ARP. There are two kind of
+      ARP configurations: global ARP configuration, which is across all
+      interfaces on the device, and per interface ARP configuration.</t>
 
-      <section title="ARP Caching">	  
-      <t>ARP caching is the method of storing network addresses and the
-	  associated data-link addresses in memory for a period of time as the
-	  addresses are learned. This minimizes the use of valuable network 
-	  resources to broadcast for the same address each time a datagram is sent. 
-	  </t>	  
-	  
-      <t>There are static ARP cache entries and dynamic ARP cache entries.
-	  Static entries are manually configured and kept in the cache table on a
-	  permanent basis. Dynamic entries are added by vendor software, kept for
-	  a period of time, and then removed. We can specify how long an entry
-	  remains in the ARP cache. If we specify a timeout of 0 seconds, entries
-	  are never cleared from the ARP cache. 
-	  </t>	  	
-	  </section>
-	  
-      <section title="proxy ARP">	  
-      <t>Proxy ARP <xref target="RFC1027"/> can be configured to enable the switch to respond
-	  to ARP queries for network addresses by offering its own Ethernet media
-	  access control (MAC) address. With proxy ARP enabled, the switch captures
-	  and routes traffic to the intended destination. 
-	  </t>
-	  </section>
-	  
-      <section title="gratuitous ARP">	  
-      <t>Gratuitous ARP requests help detect duplicate IP addresses. A gratuitous
-	  ARP is a broadcast request for a router&apos;s own IP address. If a router or
-	  switch sends an ARP request for its own IP address and no ARP replies are
-	  received, the router- or switch-assigned IP address is not being used by
-	  other nodes. However, if a router or switch sends an ARP request for its
-	  own IP address and an ARP reply is received, the router- or switch-assigned
-	  IP address is already being used by another node.
-	  </t>
-	  </section>
-	  
-	  
+      <section title="ARP dynamic learning">
+        <t>ARP caching is the method of storing network addresses and the
+        associated data-link addresses in memory for a period of time as the
+        addresses are learned. This minimizes the use of valuable network
+        resources to broadcast for the same address each time a datagram is
+        sent.</t>
+
+        <t>There are static ARP cache entries and dynamic ARP cache entries.
+        Static entries are manually configured and kept in the cache table on
+        a permanent basis. Dynamic entries are added by vendor software, kept
+        for a period of time, and then removed. We can specify how long an
+        entry remains in the ARP cache. If we specify a timeout of 0 seconds,
+        entries are never cleared from the ARP cache.</t>
+      </section>
+
+      <section title="proxy ARP">
+        <t>Proxy ARP <xref target="RFC1027"/> can be configured to enable the
+        switch to respond to ARP queries for network addresses by offering its
+        own Ethernet media access control (MAC) address. With proxy ARP
+        enabled, the switch captures and routes traffic to the intended
+        destination.</t>
+      </section>
+
+      <section title="gratuitous ARP">
+        <t>Gratuitous ARP requests help detect duplicate IP addresses. A
+        gratuitous ARP is a broadcast request for a router's own IP address.
+        If a router or switch sends an ARP request for its own IP address and
+        no ARP replies are received, the router- or switch-assigned IP address
+        is not being used by other nodes. However, if a router or switch sends
+        an ARP request for its own IP address and an ARP reply is received,
+        the router- or switch-assigned IP address is already being used by
+        another node.</t>
+      </section>
+
       <section title="ietf-arp Module ">
-      <t>This module has one top level container, ARP, which consists of
-	  two second level containers, which are used for static entries configuration and
-	  global parameters control.
-	  </t>
+        <t>This module has one top level container, ARP, which consists of two
+        second level containers, which are used for static entries
+        configuration and global parameters control.</t>
 
         <figure>
-          <artwork><![CDATA[
+          <artwork>
 module: ietf-arp
     +--rw arp
        +--rw dynamic-learning?        boolean
@@ -261,17 +306,22 @@ module: ietf-arp
           +--ro out-gratuitous-pkts?   yang:counter32
   augment /if:interfaces/if:interface/ip:ipv4/ip:neighbor:
     +--ro remaining-expiry-time?   uint32
-]]></artwork>
+</artwork>
         </figure>
       </section>
-
     </section>
 
     <section anchor="yangmodel" title="ARP YANG Module">
-      <t>This section presents the ARP YANG module defined in this document.
-      This YANG module imports typedefs from <xref target="RFC6991"/>.</t>
-      <figure><artwork><![CDATA[
-<CODE BEGINS>file "ietf-arp@2018-08-01.yang"
+      <t>This section presents the ARP YANG module defined in this document.</t>
+
+      <t>This module imports definitions from <xref target="RFC6991">Common
+      YANG Data Types</xref>, <xref target="RFC8343">A YANG Data Model for
+      Interface Management</xref>, and <xref target="RFC8344">A YANG Data
+      Model for IP Management</xref>.</t>
+
+      <figure>
+        <artwork>
+&lt;CODE BEGINS&gt;file "ietf-arp@2018-08-01.yang"
 module ietf-arp {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-arp";
@@ -281,64 +331,66 @@ module ietf-arp {
     prefix inet;
     reference "RFC 6991: Common YANG Data Types";
   }
-
   import ietf-yang-types {
     prefix yang;
     reference "RFC 6991: Common YANG Data Types";
   }
-  
   import ietf-interfaces {
     prefix if;
     reference "RFC 8343: A Yang Data Model for Interface Management";
   }
-  
   import ietf-ip {
     prefix ip;
     reference "RFC 8344: A Yang Data Model for IP Management";
-  }  
+  }
 
   organization
     "IETF Routing Area Working Group (rtgwg)";
   contact
-    "WG Web: <http://tools.ietf.org/wg/rtgwg/>
-     WG List: <mailto: rtgwg@ietf.org>
+    "WG Web: &lt;http://tools.ietf.org/wg/rtgwg/&gt;
+     WG List: &lt;mailto: rtgwg@ietf.org&gt;
      Editor: Xiaojian Ding
-         dingxiaojian1@huawei.com
+         wjswsl@163.com
      Editor: Feng Zheng
          habby.zheng@huawei.com
      Editor: Robert Wilton
          rwilton@cisco.com";
+
   description
     "Address Resolution Protocol (ARP) management, which includes
      static ARP configuration, dynamic ARP learning, ARP entry query,
-     and packet statistics collection.";
+     and packet statistics collection.
+
+    Copyright (c) 2016 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC XXXX; see the RFC
+      itself for full legal notices.";
 
   revision 2018-08-01 {
     description
       "Init revision";
-      /* NOTE TO RFC EDITOR:
-         Please replace the following reference
-         to draft-ding-rtgwg-arp-yang-model-02 with
-         RFC number when published (i.e. RFC xxxx). */
-    reference
-         "draft-ding-rtgwg-arp-yang-model-03";
+    reference "RFC XXXX: A Yang Data Model for ARP";
   }
-  
-  /*
-   * Features
-   */
+
   feature global-static-entries {
     description
       "This feature indicates that the device allows static entries
        to be configured globally.";
   }
-  
+
   container arp {
     description
       "Address Resolution Protocol (ARP) management, which includes
         static ARP configuration, dynamic ARP learning, ARP entry
         query, and packet statistics collection.";
-
     leaf dynamic-learning {
       type boolean;
       default "true";
@@ -357,9 +409,8 @@ module ietf-arp {
         "Controls the default proxy ARP behavior on all interfaces
          on the device:
            true - proxy ARP is enabled on interfaces by default,
-           false - proxy APR is disabled on interfaces by default"; 
+           false - proxy APR is disabled on interfaces by default";
     }
-
     container global-static-entries {
       if-feature "global-static-entries";
       description
@@ -383,9 +434,8 @@ module ietf-arp {
              hexadecimal number of 1 to 4 bits.";
         }
       }
-    }	
+    }
   }
-  
   augment "/if:interfaces/if:interface" {
     description
       "Augment interfaces with ARP configuration and state.";
@@ -405,10 +455,9 @@ module ietf-arp {
         default "false";
         description
           "Whether dynamic ARP learning is disabled on an interface:
-	    If the value is True, dynamic ARP learning is disabled.
-	    If the value is False, dynamic ARP learning is enabled.";
+           If the value is True, dynamic ARP learning is disabled.
+           If the value is False, dynamic ARP learning is enabled.";
       }
-	  
       container proxy {
         description
           "Configuration parameters for proxy ARP";
@@ -416,40 +465,39 @@ module ietf-arp {
           type enumeration {
             enum DISABLE {
               description
-              "The system should not respond to ARP requests that do
-	       not specify an IP address configured on the local
-	       subinterface as the target address.";
+                "The system should not respond to ARP requests that 
+                 do not specify an IP address configured on the local
+                 subinterface as the target address.";
             }
             enum REMOTE_ONLY {
               description
-              "The system responds to ARP requests only when the
-	       sender and target IP addresses are in different
-	       subnets.";
+                "The system responds to ARP requests only when the
+                 sender and target IP addresses are in different
+                 subnets.";
             }
             enum ALL {
               description
-              "The system responds to ARP requests where the sender
-	       and target IP addresses are in different subnets, as
-	       well as those where they are in the same subnet.";
+                "The system responds to ARP requests where the sender
+                 and target IP addresses are in different subnets, as
+                 well as those where they are in the same subnet.";
             }
           }
           default "DISABLE";
           description
             "When set to a value other than DISABLE, the local system
-	     should respond to ARP requests that are for target
-	     addresses other than those that are configured on the
-	     local subinterface using its own MAC address as the
-	     target hardware address. If the REMOTE_ONLY value is
-	     specified, replies are only sent when the target address
-	     falls outside the locally configured subnets on the
-	     interface, whereas with the ALL value, all requests,
-	     regardless of their target address are replied to.";
+             should respond to ARP requests that are for target
+             addresses other than those that are configured on the
+             local subinterface using its own MAC address as the
+             target hardware address. If the REMOTE_ONLY value is
+             specified, replies are only sent when the target address
+             falls outside the locally configured subnets on the
+             interface, whereas with the ALL value, all requests,
+             regardless of their target address are replied to.";
           reference
             "RFC1027: Using ARP to Implement Transparent Subnet
              Gateways";
-        }	  
+        }
       }
- 
       container probe {
         description
           "Common configuration parameters for all ARP probe.";
@@ -479,7 +527,6 @@ module ietf-arp {
              entry.";
         }
       }
-	  
       container gratuitous-arp {
         description
           "Configure gratuitous ARP.";
@@ -507,7 +554,6 @@ module ietf-arp {
              interface.";
         }
       }
-	  
       container statistics {
         config false;
         description
@@ -544,8 +590,7 @@ module ietf-arp {
         }
       }
     }
-  }		  
-				
+  }
   augment "/if:interfaces/if:interface/ip:ipv4/ip:neighbor" {
     description
       "Augment neighbor list with parameters of ARP, eg., support for
@@ -558,9 +603,9 @@ module ietf-arp {
     }
   }
 }
-]]></artwork>
-      </figure>
 
+</artwork>
+      </figure>
     </section>
 
     <!---->
@@ -633,18 +678,41 @@ Enable ARP dynamic learning configuration.
       </section>
     </section>
 
+    <section title="IANA Considerations">
+      <t>This document registers a URI in the<xref target="RFC3688">IETF XML
+      registry</xref>. Following the format in <xref target="RFC3688"/>, the
+      following registration is requested to be made:</t>
+
+      <figure>
+        <artwork>URI: urn:ietf:params:xml:ns:yang:ietf-arp
+Registrant Contact: The IESG.
+XML: N/A, the requested URI is an XML namespace.
+</artwork>
+      </figure>
+
+      <t>This document registers a YANG module in the YANG Module Names
+      registry <xref target="RFC7950"/>.</t>
+
+      <figure>
+        <artwork>Name: ietf-arp
+Namespace: urn:ietf:params:xml:ns:yang: ietf-arp
+Prefix: arp
+Reference: RFC XXXX
+</artwork>
+      </figure>
+    </section>
+
     <section anchor="security" title="Security Considerations">
       <t>The YANG module defined in this document is designed to be accessed
-      via YANG based management protocols, such as NETCONF <xref target="RFC6241"/> and
-      RESTCONF <xref target="RFC8040"/>. Both of these protocols have mandatory-to- implement
-      secure transport layers (e.g., SSH, TLS) with mutual authentication.</t>
+      via YANG based management protocols, such as NETCONF <xref
+      target="RFC6241"/> and RESTCONF <xref target="RFC8040"/>. Both of these
+      protocols have mandatory-to- implement secure transport layers (e.g.,
+      SSH, TLS) with mutual authentication.</t>
 
-      <t>The NETCONF access control model (NACM) <xref target="RFC6536"/> provides the means
-      to restrict access for particular users to a pre-configured subset of
-      all available protocol operations and content.</t>
-
-      <t>These are the subtrees and data nodes and their
-      sensitivity/vulnerability:</t>
+      <t>The NETCONF access control model (NACM) <xref target="RFC8341"/>
+      provides the means to restrict access for particular users to a
+      pre-configured subset of all available protocol operations and
+      content.</t>
 
       <t>There are a number of data nodes defined in this YANG module that are
       writable/creatable/deletable (i.e., config true, which is the default).
@@ -652,6 +720,30 @@ Enable ARP dynamic learning configuration.
       network environments. Write operations (e.g., edit-config) to these data
       nodes without proper protection can have a negative effect on network
       operations.</t>
+
+      <t>These are the subtrees and data nodes and their
+      sensitivity/vulnerability:</t>
+
+      <t><list style="hanging">
+          <t>arp/dynamic-learning: This leaf is used to enable ARP dynamic
+          learning on all interfaces.ARP dynamic learning could allow an
+          attacker to inject spoofed traffic into the network, e.g. denial-of-
+          service attack.</t>
+
+          <t>arp/proxy-arp and arp/proxy:These leaves are used to enable ARP
+          proxy on interface. They could allow traffic to be mis-configured
+          (denial-of- service attack).</t>
+
+          <t>arp/global-static-entries/static-entry: This list specifies ARP
+          static entries configured on the device. By modifying this
+          information, an attacker can cause a node to either ignore messages
+          destined to it or accept messages it would otherwise ignore. </t>
+
+          <t>/arp/gratuitous-arp:This leaf is used to enable sending
+          gratuitous ARP packet on an interface.This configuration could allow
+          an attacker to inject spoofed traffic into the network, e.g.
+          man-in-the-middle attack.</t>
+        </list></t>
     </section>
 
     <section anchor="ack" title="Acknowledgments">
@@ -664,8 +756,10 @@ Enable ARP dynamic learning configuration.
 
   <back>
     <references title="Normative References">
+      &rfc0826;
       &rfc1027;
       &rfc2119;
+      &rfc3688;
       &rfc6991;
       &rfc7950;
       &rfc8174;
@@ -675,11 +769,10 @@ Enable ARP dynamic learning configuration.
     </references>
 
     <references title="Informative References">
-      &rfc826;
       &rfc6241;
-      &rfc6536;
       &rfc8040;
       &rfc8340;
+      &rfc8341;
     </references>
   </back>
 </rfc>

--- a/ietf-arp.yang
+++ b/ietf-arp.yang
@@ -7,21 +7,18 @@ module ietf-arp {
     prefix inet;
     reference "RFC 6991: Common YANG Data Types";
   }
-
   import ietf-yang-types {
     prefix yang;
     reference "RFC 6991: Common YANG Data Types";
   }
-  
   import ietf-interfaces {
     prefix if;
     reference "RFC 8343: A Yang Data Model for Interface Management";
   }
-  
   import ietf-ip {
     prefix ip;
     reference "RFC 8344: A Yang Data Model for IP Management";
-  }  
+  }
 
   organization
     "IETF Routing Area Working Group (rtgwg)";
@@ -29,42 +26,47 @@ module ietf-arp {
     "WG Web: <http://tools.ietf.org/wg/rtgwg/>
      WG List: <mailto: rtgwg@ietf.org>
      Editor: Xiaojian Ding
-         dingxiaojian1@huawei.com
+         wjswsl@163.com
      Editor: Feng Zheng
          habby.zheng@huawei.com
      Editor: Robert Wilton
          rwilton@cisco.com";
+
   description
     "Address Resolution Protocol (ARP) management, which includes
      static ARP configuration, dynamic ARP learning, ARP entry query,
-     and packet statistics collection.";
+     and packet statistics collection.
+
+    Copyright (c) 2016 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC XXXX; see the RFC
+      itself for full legal notices.";
 
   revision 2018-08-01 {
     description
       "Init revision";
-      /* NOTE TO RFC EDITOR:
-         Please replace the following reference
-         to draft-ding-rtgwg-arp-yang-model-02 with
-         RFC number when published (i.e. RFC xxxx). */
-    reference
-         "draft-ding-rtgwg-arp-yang-model-03";
+    reference "RFC XXXX: A Yang Data Model for ARP";
   }
-  
-  /*
-   * Features
-   */
+
   feature global-static-entries {
     description
       "This feature indicates that the device allows static entries
        to be configured globally.";
   }
-  
+
   container arp {
     description
       "Address Resolution Protocol (ARP) management, which includes
         static ARP configuration, dynamic ARP learning, ARP entry
         query, and packet statistics collection.";
-
     leaf dynamic-learning {
       type boolean;
       default "true";
@@ -83,9 +85,8 @@ module ietf-arp {
         "Controls the default proxy ARP behavior on all interfaces
          on the device:
            true - proxy ARP is enabled on interfaces by default,
-           false - proxy APR is disabled on interfaces by default"; 
+           false - proxy APR is disabled on interfaces by default";
     }
-
     container global-static-entries {
       if-feature "global-static-entries";
       description
@@ -109,9 +110,8 @@ module ietf-arp {
              hexadecimal number of 1 to 4 bits.";
         }
       }
-    }	
+    }
   }
-  
   augment "/if:interfaces/if:interface" {
     description
       "Augment interfaces with ARP configuration and state.";
@@ -131,10 +131,9 @@ module ietf-arp {
         default "false";
         description
           "Whether dynamic ARP learning is disabled on an interface:
-	    If the value is True, dynamic ARP learning is disabled.
-	    If the value is False, dynamic ARP learning is enabled.";
+           If the value is True, dynamic ARP learning is disabled.
+           If the value is False, dynamic ARP learning is enabled.";
       }
-	  
       container proxy {
         description
           "Configuration parameters for proxy ARP";
@@ -142,40 +141,39 @@ module ietf-arp {
           type enumeration {
             enum DISABLE {
               description
-              "The system should not respond to ARP requests that do
-	       not specify an IP address configured on the local
-	       subinterface as the target address.";
+                "The system should not respond to ARP requests that 
+                 do not specify an IP address configured on the local
+                 subinterface as the target address.";
             }
             enum REMOTE_ONLY {
               description
-              "The system responds to ARP requests only when the
-	       sender and target IP addresses are in different
-	       subnets.";
+                "The system responds to ARP requests only when the
+                 sender and target IP addresses are in different
+                 subnets.";
             }
             enum ALL {
               description
-              "The system responds to ARP requests where the sender
-	       and target IP addresses are in different subnets, as
-	       well as those where they are in the same subnet.";
+                "The system responds to ARP requests where the sender
+                 and target IP addresses are in different subnets, as
+                 well as those where they are in the same subnet.";
             }
           }
           default "DISABLE";
           description
             "When set to a value other than DISABLE, the local system
-	     should respond to ARP requests that are for target
-	     addresses other than those that are configured on the
-	     local subinterface using its own MAC address as the
-	     target hardware address. If the REMOTE_ONLY value is
-	     specified, replies are only sent when the target address
-	     falls outside the locally configured subnets on the
-	     interface, whereas with the ALL value, all requests,
-	     regardless of their target address are replied to.";
+             should respond to ARP requests that are for target
+             addresses other than those that are configured on the
+             local subinterface using its own MAC address as the
+             target hardware address. If the REMOTE_ONLY value is
+             specified, replies are only sent when the target address
+             falls outside the locally configured subnets on the
+             interface, whereas with the ALL value, all requests,
+             regardless of their target address are replied to.";
           reference
             "RFC1027: Using ARP to Implement Transparent Subnet
              Gateways";
-        }	  
+        }
       }
- 
       container probe {
         description
           "Common configuration parameters for all ARP probe.";
@@ -205,7 +203,6 @@ module ietf-arp {
              entry.";
         }
       }
-	  
       container gratuitous-arp {
         description
           "Configure gratuitous ARP.";
@@ -233,7 +230,6 @@ module ietf-arp {
              interface.";
         }
       }
-	  
       container statistics {
         config false;
         description
@@ -270,8 +266,7 @@ module ietf-arp {
         }
       }
     }
-  }		  
-				
+  }
   augment "/if:interfaces/if:interface/ip:ipv4/ip:neighbor" {
     description
       "Augment neighbor list with parameters of ARP, eg., support for


### PR DESCRIPTION
For the draft,changes include：
1.RFC Editor note:asking them to replace the YANG module dates with date of publication. I suggest a Note asking them to replace XXXX with the number assigned to this I-D at the start of the I-D rather than asking them to replace 'draft-ding-rtgwg-arp-yang-model-02 ' which, should this I-D be adopted, will be wrong

2. references for several imported modules.

3. IANA Considerations;

4. Security Considerations add detail of sensitive nodes

For the YANG
1..Copyright statement in the YANG module

